### PR TITLE
Add pg_show_plans.skip_queryids guc

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ query |
  - *plan*: the query plan of the running query.
 
 ## Configuration Parameters
+ - *pg_show_plans.skip_queryids* : text that defines a list of queryid (max 20 values) whose plans will be skipped. Default is none.
  - *pg_show_plans.startup_enable* : Boolean that defines if plans are enabled at startup, or not. Default is `true`.
  - *pg_show_plans.plan_format* : It controls the output format of query plans. It can be selected either `text` or `json`. Default is `text`.
  - *pg_show_plans.max_plan_length* : It sets the maximum length of query plans. Default is `8192` [byte]. Note that this parameter must be set to an integer.


### PR DESCRIPTION
this is to try a new guc: pg_show_plans.skip_queryids,
that contains a list of queryids that won't have their plan displayed.

testing:

do $$ declare i int;j int; begin for i in 1..1000000 loop select 1 into j; end loop; end; $$;

initial configuration: 
explain (costs off)
pg_show_plans_enable
pgss.track='all'
pgsp.skip_queryids not set (NULL)

```
			skip_queryids	NULL	1(*)	10(**)
select 1+1 				2300	2350	2350
select 1				2300	1570	1570
	pgss.track='none'		2040
	pg_show_plans_disable		1220
```
	
 (*) skip_queryids containing queryid of "select 1" statement.
 (**) skip_queryids containing queryid of "select 1" statement + 9 others


Impact on non skipped queries like "select 1+1" stay very low (2350 ms / 2300 ms)