### PR TITLE
Add Queryid and support for remanant plans

### DIFF
--- a/pg_show_plans--1.0.sql
+++ b/pg_show_plans--1.0.sql
@@ -29,6 +29,7 @@ CREATE FUNCTION pg_show_plans(
     OUT level int8,
     OUT userid oid,
     OUT dbid oid,
+	OUT queryid bigint,
     OUT plan text
 )
 RETURNS SETOF record

--- a/pg_show_plans.c
+++ b/pg_show_plans.c
@@ -324,7 +324,7 @@ pgsp_shmem_startup(void)
 static void
 pgsp_on_proc_exit(int code, Datum arg)
 {
-	entry_delete(getpid(), 0);
+	entry_delete(MyProcPid, 0);
 	return;
 }
 
@@ -660,7 +660,7 @@ entry_store(char *plan, const int nested_level, const uint64 QueryId)
 	if (!pgsp || !pgsp_hash)
 		return;
 
-	key.pid = getpid();
+	key.pid = MyProcPid;
 	key.nested_level = nested_level;
 	plan_len = strlen(plan);
 


### PR DESCRIPTION
View pg_show_plans now contains a queryid column, that comes from pg_stat_statements for common queries (=0 if track=false), and is the same hash function than pg_stat_statements for utility statements.

In original extension, plans where displayed only when they were running. Here, they are kept until there is a new query executed in the session (even when cancelled), to be in sync with pg_stat_activity.query content. Utility statements have been included.

a query like can help for monitoring (userid and dbid should be added in join):
select backend_type,pid,state,query,level,queryid,plan
from pg_stat_activity left join pg_show_plans using (pid)
where  pid!=pg_backend_pid() and backend_type='client backend';

maybe this will be the base for a pg_stat_activity_extended view.

In the original extension, plans where created and deleted at the query start and end (commit).
Here plans are created when the session starts, are simply *updated* with queries (and utility statements) executions, and deleted on session exit.
 